### PR TITLE
Corrected the name of imported 'Concatenate' layer

### DIFF
--- a/week5/RNN-task.ipynb
+++ b/week5/RNN-task.ipynb
@@ -251,7 +251,7 @@
    "outputs": [],
    "source": [
     "import keras\n",
-    "from keras.layers import concatenate, Dense, Embedding\n",
+    "from keras.layers import Concatenate, Dense, Embedding\n",
     "\n",
     "rnn_num_units = 64  # size of hidden state\n",
     "embedding_size = 16  # for characters\n",


### PR DESCRIPTION
"from keras.layers import concatenate" was updated to "from keras.layers import Concatenate" which caused error otherwise.